### PR TITLE
fix file namein(res2.json.bmp -> res2.bmp), fix compression call

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,7 +70,7 @@ func validateFrameworkConfiguration() {
                 log.Fatal("Cannot use both --gz-bitmap-format and --bitmap-format simultaineously.")
         }
         if (config.BitmapFormat || config.GzBitmapFormat) && config.ScanSuccessKeys == "" {
-                log.Fatal("Set --scan--success-keys parameter(i.e. for ntp - \"data.ntp.result.monlist_response\").")
+                log.Fatal("Set --scan-success-keys parameter(i.e. for ntp - \"data.ntp.result.monlist_response\").")
         }
 
         if config.BitmapFormat {
@@ -96,16 +96,16 @@ func validateFrameworkConfiguration() {
 		var err error
 
 		if config.BitmapFormat {
-			config.OutputFileName += ".json"
 			if config.outputBitmapFile, err = os.Create(config.OutputFileName + ".bmp"); err != nil {
 				log.Fatal(err)
 			}
+                        config.OutputFileName += ".json"
 		}
                 if config.GzBitmapFormat {
-                        config.OutputFileName += ".json"
                         if config.outputBitmapFile, err = os.Create(config.OutputFileName + ".bmp.gz"); err != nil {
                                 log.Fatal(err)
                         }
+                        config.OutputFileName += ".json"
                 }
 
 		if config.outputFile, err = os.Create(config.OutputFileName); err != nil {

--- a/output.go
+++ b/output.go
@@ -175,7 +175,7 @@ func OutputResultsFileBitmap(results <-chan []byte) error {
 }
 
 func OutputResultsFileGzipBitmap(results <-chan []byte) error {
-        return GetResultsFileBitmap(results, false)
+        return GetResultsFileBitmap(results, true)
 }
 
 func allKeysAreInJson(jsonString []byte, keyPaths [][]string) bool {


### PR DESCRIPTION
Test for fixes:

1. --scan--success-keys -> --scan-success-keys

# ./zgrab2 ntp -f filtered.bmp.gz -o res2 --gz-bitmap-format --monlist
FATA[0000] Set --scan-success-keys parameter(i.e. for ntp - "data.ntp.result.monlist_response"). 

2. check gz creation

# ./zgrab2 ntp -f filtered.bmp.gz -o res2 --gz-bitmap-format --scan-success-keys data.ntp.result.monlist_response --monlist
INFO[0000] started grab at 2019-03-14T18:23:49-08:00    
INFO[0133] finished grab at 2019-03-14T18:26:02-08:00   
{"statuses":{"ntp":{"successes":656,"failures":12153}},"start":"2019-03-14T18:23:49-08:00","end":"2019-03-14T18:26:02-08:00","duration":"2m13.6882664s"}

# ls -l
-rw-r--r-- 1 root root   524726 Mar 14 18:26 res2.bmp.gz
-rw-r--r-- 1 root root  2725416 Mar 14 18:26 res2.json

# du -h res2.*
516K	res2.bmp.gz
2.7M	res2.json

# gunzip res2.bmp.gz 
root@2089e95fc741:~/go/src/github.com/zmap/zgrab2/cmd/zgrab2# du -h res2.*
513M	res2.bmp
2.7M	res2.json

3. check correct filenames

# ls -l
-rw-r--r-- 1 root root   524726 Mar 14 18:26 res2.bmp.gz
-rw-r--r-- 1 root root  2725416 Mar 14 18:26 res2.json