### PR TITLE
support for local-address

### DIFF
--- a/module.go
+++ b/module.go
@@ -68,12 +68,12 @@ type BaseFlags struct {
 	Timeout        time.Duration `short:"t" long:"timeout" description:"Set connection timeout (0 = no timeout)" default:"10s"`
 	Trigger        string        `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
 	BytesReadLimit int           `short:"m" long:"maxbytes" description:"Maximum byte read limit per scan (0 = defaults)"`
+	LocalAddress   string        `short:"l" long:"local-addr" description:"Set an explicit local address for traffic"`
 }
 
 // UDPFlags contains the common options used for all UDP scans
 type UDPFlags struct {
 	LocalPort    uint   `long:"local-port" description:"Set an explicit local port for UDP traffic"`
-	LocalAddress string `long:"local-addr" description:"Set an explicit local address for UDP traffic"`
 }
 
 // GetName returns the name of the respective scanner

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -623,7 +623,7 @@ func (scan *scan) getCheckRedirect(scanner *Scanner) func(*http.Request, *http.R
 // Taken from zgrab2 http library, slightly modified to use slightly leaner scan object
 func (scan *scan) getTLSDialer(scanner *Scanner) func(net, addr string) (net.Conn, error) {
 	return func(net, addr string) (net.Conn, error) {
-		outer, err := zgrab2.DialTimeoutConnection(net, addr, scanner.config.BaseFlags.Timeout, 0)
+		outer, err := zgrab2.DialTimeoutConnection(net, scanner.config.BaseFlags.LocalAddress, addr, scanner.config.BaseFlags.Timeout, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/processing.go
+++ b/processing.go
@@ -57,7 +57,7 @@ func (target *ScanTarget) Host() string {
 // Open connects to the ScanTarget using the configured flags, and returns a net.Conn that uses the configured timeouts for Read/Write operations.
 func (target *ScanTarget) Open(flags *BaseFlags) (net.Conn, error) {
 	address := net.JoinHostPort(target.Host(), fmt.Sprintf("%d", flags.Port))
-	return DialTimeoutConnection("tcp", address, flags.Timeout, flags.BytesReadLimit)
+	return DialTimeoutConnection("tcp", flags.LocalAddress, address, flags.Timeout, flags.BytesReadLimit)
 }
 
 // OpenTLS connects to the ScanTarget using the configured flags, then performs
@@ -77,10 +77,10 @@ func (target *ScanTarget) OpenTLS(baseFlags *BaseFlags, tlsFlags *TLSFlags) (*TL
 func (target *ScanTarget) OpenUDP(flags *BaseFlags, udp *UDPFlags) (net.Conn, error) {
 	address := net.JoinHostPort(target.Host(), fmt.Sprintf("%d", flags.Port))
 	var local *net.UDPAddr
-	if udp != nil && (udp.LocalAddress != "" || udp.LocalPort != 0) {
+	if udp != nil && (flags.LocalAddress != "" || udp.LocalPort != 0) {
 		local = &net.UDPAddr{}
-		if udp.LocalAddress != "" && udp.LocalAddress != "*" {
-			local.IP = net.ParseIP(udp.LocalAddress)
+		if flags.LocalAddress != "" && flags.LocalAddress != "*" {
+			local.IP = net.ParseIP(flags.LocalAddress)
 		}
 		if udp.LocalPort != 0 {
 			local.Port = int(udp.LocalPort)


### PR DESCRIPTION
In order to use local-address for route rule selection, zgrab2 needs the ability to set the local address explicitly.

We can see `net.DialTimeout` API doesn't have local address parameter. So created a new one `DialTimeoutWithLocalAddr` to be able to set the local address explicitly.

```
B+ │324     func DialTimeout(network, address string, timeout time.Duration) (Conn, error) {                                        │
   │325             d := Dialer{Timeout: timeout}                                                                                   │
  >│326             return d.Dial(network, address)                                                                                 │
   │327     }
```

## How to Test
```
cat https.input
172.217.25.174
13.236.229.21
```
```
./zgrab2 tls --local-addr 146.88.240.2 --senders 1 --input-file https.input | jq .
```

## Notes & Caveats
This `local-addr` is supporting all protocols in zgrab2, so it won't impact the existing protocol who had `local-addr` like those udp based protocols.

## Issue Tracking
N/A