### PR TITLE
tls scan to ginore error log

### DIFF
--- a/modules/tls.go
+++ b/modules/tls.go
@@ -82,7 +82,7 @@ func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, 
 				if log.HandshakeLog.ServerHello != nil {
 					// If we got far enough to get a valid ServerHello, then
 					// consider it to be a positive TLS detection.
-					return zgrab2.TryGetScanStatus(err), log, err
+					return zgrab2.TryGetScanStatus(err), nil, err
 				}
 				// Otherwise, detection failed.
 			}


### PR DESCRIPTION
When error happens it left parts of handshake result, example below, ignore it for less spam.

```
{"ip":"203.80.10.13","data":{"tls":{"status":"unknown-error","protocol":"tls","result":{"handshake_log":{"server_hello":{"version":{"name":"TLSv1.0","value":769},"random":"V6Kb2owjLe2crNC/7nez0eYDRS2BbG5K6rmFfKStOxs=","session_id":"6J447CK6Z5EIj54tNEH5AIj8ZSkR+w74W3du58x6B7U=","cipher_suite":{"hex":"0x002F","name":"TLS_RSA_WITH_AES_128_CBC_SHA","value":47},"compression_method":0,"ocsp_stapling":false,"ticket":false,"secure_renegotiation":false,"heartbeat":false,"extended_master_secret":false},"server_certificates":{"certificate":{"raw":"MIIDeDCCAuGgAwIBAgIJAL8nRFEnr27AMA0GCSqGSIb3DQEBBQUAMIGFMQswCQYDVQQGEwJDQTEQMA4GA1UECBMHT250YXJpbzEPMA0GA1UEBxMGT3R0YXdhMRcwFQYDVQQKEw5pRGlyZWN0IENhbmFkYTEMMAoGA1UECxMDU0ZGMQswCQYDVQQDEwJYMTEfMB0GCSqGSIb3DQEJARYQaGVscEBpZGlyZWN0Lm5ldDAeFw0xMTEwMjUwODA0MjVaFw00ODAyMDMwODA0MjVaMIGFMQswCQYDVQQGEwJDQTEQMA4GA1UECBMHT250YXJpbzEPMA0GA1UEBxMGT3R0YXdhMRcwFQYDVQQKEw5pRGlyZWN0IENhbmFkYTEMMAoGA1UECxMDU0ZGMQswCQYDVQQDEwJYMTEfMB0GCSqGSIb3DQEJARYQaGVscEBpZGlyZWN0Lm5ldDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAyaA3Tm0DFwaAIlGrW+8MLeVRl2YreiGMC5qvAslymp3TMzbvz6jLAyiMlyQoyt9i0R6qI9Y7xgCib5yyUutJkHWcUE+hO6QwdydkRBskX6rebYZ3N69gTTrX5jDVKYQXjIWI74CbEJcQrPennWpaJJfylm+tyFB+LucAR6+5hNkCAwEAAaOB7TCB6jAdBgNVHQ4EFgQUQUF6XwV1LLYaf/J7N5uwEw14SSIwgboGA1UdIwSBsjCBr4AUQUF6XwV1LLYaf/J7N5uwEw14SSKhgYukgYgwgYUxCzAJBgNVBAYTAkNBMRAwDgYDVQQIEwdPbnRhcmlvMQ8wDQYDVQQHEwZPdHRhd2ExFzAVBgNVBAoTDmlEaXJlY3QgQ2FuYWRhMQwwCgYDVQQLEwNTRkYxCzAJBgNVBAMTAlgxMR8wHQYJKoZIhvcNAQkBFhBoZWxwQGlkaXJlY3QubmV0ggkAvydEUSevbsAwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQBC5MJDSEX4QQ1UBVCBlQKQ6zb/HGACzYmZKjHP5Usv2uWOJeiwuKPie+f2CBnv2G7QzFljx+n7tZJUvGIhbOUiFDa+CWOAB2nK3QJYO/K21y3UG89uBv3qM0G6Bm1PU6aswJzkWH8U1lKG/D1vJ7DH6vrfGxqNApJt092YbOAjCg==","parsed":{"version":3,"serial_number":"13774053100684799680","signature_algorithm":{"name":"SHA1-RSA","oid":"1.2.840.113549.1.1.5"},"issuer":{"common_name":["X1"],"country":["CA"],"locality":["Ottawa"],"province":["Ontario"],"organization":["iDirect Canada"],"organizational_unit":["SFF"],"email_address":["help@idirect.net"]},"issuer_dn":"C=CA, ST=Ontario, L=Ottawa, O=iDirect Canada, OU=SFF, CN=X1, emailAddress=help@idirect.net","validity":{"start":"2011-10-25T08:04:25Z","end":"2048-02-03T08:04:25Z","length":1144800000},"subject":{"common_name":["X1"],"country":["CA"],"locality":["Ottawa"],"province":["Ontario"],"organization":["iDirect Canada"],"organizational_unit":["SFF"],"email_address":["help@idirect.net"]},"subject_dn":"C=CA, ST=Ontario, L=Ottawa, O=iDirect Canada, OU=SFF, CN=X1, emailAddress=help@idirect.net","subject_key_info":{"key_algorithm":{"name":"RSA"},"rsa_public_key":{"exponent":65537,"modulus":"yaA3Tm0DFwaAIlGrW+8MLeVRl2YreiGMC5qvAslymp3TMzbvz6jLAyiMlyQoyt9i0R6qI9Y7xgCib5yyUutJkHWcUE+hO6QwdydkRBskX6rebYZ3N69gTTrX5jDVKYQXjIWI74CbEJcQrPennWpaJJfylm+tyFB+LucAR6+5hNk=","length":1024},"fingerprint_sha256":"b6886af34f06ae7a4c5c3c7b037e1aa96f59c78694f901654503ad3c4cbe0eb7"},"extensions":{"basic_constraints":{"is_ca":true},"authority_key_id":"41417a5f05752cb61a7ff27b379bb0130d784922","subject_key_id":"41417a5f05752cb61a7ff27b379bb0130d784922"},"signature":{"signature_algorithm":{"name":"SHA1-RSA","oid":"1.2.840.113549.1.1.5"},"value":"QuTCQ0hF+EENVAVQgZUCkOs2/xxgAs2JmSoxz+VLL9rljiXosLij4nvn9ggZ79hu0MxZY8fp+7WSVLxiIWzlIhQ2vgljgAdpyt0CWDvyttct1BvPbgb96jNBugZtT1OmrMCc5Fh/FNZShvw9byewx+r63xsajQKSbdPdmGzgIwo=","valid":true,"self_signed":true},"fingerprint_md5":"75c7489d56799ff2c01e14eb87804ae0","fingerprint_sha1":"25bf2b80f9ba0336d452df381aef0e80e2d8bdac","fingerprint_sha256":"c4c785899cf881ff29e49af966103515578c52c8660e838945fdc2f6e2c7e555","tbs_noct_fingerprint":"21c6ffa7f5e7844397e312432b3b964400f50109e7428f6c86281eab893f9ae9","spki_subject_fingerprint":"7f7f105b09ed13f6e72e8502d4812038e7c39f1227e6d6eef5f4c2b12f6056ff","tbs_fingerprint":"21c6ffa7f5e7844397e312432b3b964400f50109e7428f6c86281eab893f9ae9","validation_level":"unknown","redacted":false}},"validation":{"browser_trusted":false,"browser_error":"x509: failed to load system roots and no roots provided"}},"client_key_exchange":{"rsa_params":{"length":128,"encrypted_pre_master_secret":"urj3Ue2XhJ4UWFFJhSfktsR+05qGke3hfxGnl1gA9YdNbc1biRTHK1HM49m4eXzdZuunsqcQFgw2sW7ggOoh8muJBlx8Lcoh9u5HXof+qeY3L811TNOV+5qSCKj9t16BnNOvjhWonwOh29H8cOem/79q9llt4HGrIMGdAk7HPZM="}},"client_finished":{"verify_data":"eenvkSkr735jnwkA"}}},"timestamp":"2019-06-16T06:19:50-04:00","error":"remote error: bad record MAC"}}}
```
## How to Test
Run grabbing for big amount of IPs.
`{"ip":"89.240.14.88","data":{"tls":{"status":"unknown-error","protocol":"tls","timestamp":"2019-06-16T18:34:42-04:00","error":"local error: bad record MAC"}}}`
## Notes & Caveats
N/A

## Issue Tracking
N/A